### PR TITLE
Remove dependency on DataFrames while preserving functionality

### DIFF
--- a/src/Mustache.jl
+++ b/src/Mustache.jl
@@ -1,6 +1,6 @@
 module Mustache
 
-using DataFrames
+# using DataFrames
 
 include("utils.jl")
 include("tokens.jl")

--- a/src/context.jl
+++ b/src/context.jl
@@ -63,13 +63,13 @@ function lookup_in_view(view::Dict, key)
     end
 end
 
-function lookup_in_view(view::DataFrame, key)
-    if has(view, key)
-        view[1, key] ## first element only
-    else
-        nothing
-    end
-end
+# function lookup_in_view(view::Main.DataFrame, key)
+#     if has(view, key)
+#         view[1, key] ## first element only
+#     else
+#         nothing
+#     end
+# end
 
 function lookup_in_view(view::Module, key)
     hasmatch = false
@@ -92,8 +92,17 @@ end
 
 ## Default is likely not great, but we use CompositeKind
 function lookup_in_view(view, key)
-
-    nms = names(view)
+    
+    if Main.isdefined(:DataFrame) && typeof(view) == Main.DataFrame
+        # Adapted from line 66
+        if has(view, key)
+            return view[1, key] ## first element only
+        else
+            return nothing
+        end
+    else
+        nms = names(view)
+    end
     re = Regex(key)
     has_match = false
     for i in nms

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -217,19 +217,19 @@ function renderTokens(io, tokens, writer, context, template)
             ##  many things based on value of value
             if isa(value, Dict)
                 for (k, v) in value
-                    print(io, renderTokens(token[5], writer, ctx_push(context, v), template))
+                    renderTokens(io, token[5], writer, ctx_push(context, v), template)
                 end
             elseif isa(value, Array)
                 for v in value
-                    print(io, renderTokens(token[5], writer, ctx_push(context, v), template))
+                    renderTokens(io, token[5], writer, ctx_push(context, v), template)
                 end
-            elseif isa(value, DataFrame)
+            elseif Main.isdefined(:DataFrame) && isa(value, Main.DataFrame)
                 ## iterate along row, Call one for each row
                 for i in 1:size(value)[1] 
-                    print(io, renderTokens(token[5], writer, ctx_push(context, value[i,:]), template))
+                    renderTokens(io, token[5], writer, ctx_push(context, value[i,:]), template)
                 end
             elseif !falsy(value)
-                print(io, renderTokens(token[5], writer, context, template))
+                renderTokens(io, token[5], writer, context, template)
             end
             
         elseif token[1] == "^"
@@ -237,7 +237,7 @@ function renderTokens(io, tokens, writer, context, template)
             value = lookup(context, tokenValue)
             
             if falsy(value)
-                print(io, renderTokens(token[5], writer, context, template))
+                renderTokens(io, token[5], writer, context, template)
             end
             
             

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -1,6 +1,7 @@
 ## Some simple tests of the package
 
-using Mustache; 
+using Mustache
+mtrender = render
 
 tpl = mt"the value of x is {{x}} and that of y is {{y}}"
 
@@ -93,10 +94,10 @@ A = [{"a" => "eh", "b" => "bee"},
      {"a" => "ah", "b" => "buh"}]
 
 ## Contrast to data frame:
-D = DataFrame(quote
-  a = ["eh", "ah"]
-  b = ["bee", "buh"]
-end)
+# D = DataFrame(quote
+#   a = ["eh", "ah"]
+#   b = ["bee", "buh"]
+# end);
 
 tpl = mt"{{#A}} pronounce a as {{a}} and b as {{b}}.{{/A}}"
 


### PR DESCRIPTION
DataFrames takes _way too long_ to load and isn't needed for the the majority of Mustache's functionality, so I adjusted the context lookup functions to use DataFrames only if it's been loaded by the user and removed the dependency on and loading of DataFrames by Mustache.

In short, everything still works and it loads much faster if you don't use DataFrames.

I also fixed a couple bugs in the tokenizing and tests.
