### PR TITLE
Escape $

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,3 @@
-
 ## regular expressions to use
 whiteRe = r"\s*"
 spaceRe = r"\s+"
@@ -45,7 +44,7 @@ end
 
 ## Make these work
 function escapeRe(string)
-    replace(string, r"[\-\[\]{}()*+?.,\\\^$|#\s]", "\\$&");
+    replace(string, r"[\-\[\]{}()*+?.,\\\^$|#\s]", "\\\$&");
 end
 
 function escapeTags(tags)


### PR DESCRIPTION
Recent changes in Julia's string interpolation has made it necessary to quote the $ character. 

Without this change, we get, using latest master, `Version 0.2.0` , commit: `5119472` 

``` jlcon
julia> using Mustache
ERROR: syntax: invalid interpolation syntax: &
 in include_from_node1 at loading.jl:89
 in include_from_node1 at loading.jl:89
 in reload_path at loading.jl:109
 in require at loading.jl:48
at /Users/aviks/.julia/Mustache/src/utils.jl:48
at /Users/aviks/.julia/Mustache/src/Mustache.jl:5
```
