### PR TITLE
Replaced entityMap Dict with list of tuples

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -36,7 +36,6 @@ entityMap = [("&", "&amp;"),
 function escape_html(x)
     y = string(x)
     for (k,v) in entityMap
-        println(k, v)
         y = replace(y, k, v)
     end
     y


### PR DESCRIPTION
Dicts are unordered, so using a Dict did not guarantee that "&"s would be replaced before other characters. 

e.g. a "<" would be replaced with "&lt;" and then escaped again to "&amp;lt;". Using a list ensures "&"s are escaped first.
