### PR TITLE
Unexported names in modules

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -74,7 +74,7 @@ end
 function lookup_in_view(view::Module, key)
     hasmatch = false
     re = Regex("^$key\$")
-    for i in names(view)
+    for i in names(view, true)
         if ismatch(re, string(i))
             hasmatch = true
             break


### PR DESCRIPTION
John, first of all, thanks very much for writing Mustache.jl. It is proving useful for generating some tedious input files for simulations.

This pull request is to allow this to work:

``` julia
module X
x = 1; y = "two"
end
render(tpl, X) | println
```

Modules are the handiest way to prepare data for Mustache, and it's nice to not have to export the names.
