### PR TITLE
Fix overwritten method (warns on v0.5)

### DIFF
--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -216,12 +216,6 @@ function _renderTokensByValue(value::Array, io, token, writer, context, template
     end
 end
 
-function _renderTokensByValue(value::Function, io, token, writer, context, template)
-    for v in value
-        renderTokens(io, token[5], writer, ctx_push(context, v), template)
-    end
-end
-
 ## ## DataFrames
 ## function renderTokensByValue(value::DataFrames.DataFrame, io, token, writer, context, template)
 ##     ## iterate along row, Call one for each row


### PR DESCRIPTION
This fixes what seems to have been a typo, which went unnoticed in julia v0.4.x, but which now causes a warning whenever Mustache.jl is used (because overwritten methods now always cause a warning in v0.5).