### PR TITLE
deprecate `is`

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -43,7 +43,7 @@ function lookup(ctx::Context, key)
         ctx._cache[key] = value
     end
 
-    if is(value, Function)
+    if value === Function
         value = value()
     end
 


### PR DESCRIPTION
 `is` has been deprecated for Julia 0.6.0 milestone.

thanks.