### PR TITLE
introduce vector index notation. Close #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,16 +252,15 @@ tpl = """
 {{^.[1]}}{{.}}{{/.[1]}}
 {{/:vec}}
 """
-render(tpl, vec = ["A1", "B2", "C3"])  # "A1, B2, C3"
+render(tpl, vec = ["A1", "B2", "C3"])  # basically "<bold>A1</bold>B2 C3"
 ```
 
 This was inspired by
 [this](http://stackoverflow.com/questions/11147373/only-show-the-first-item-in-list-using-mustache)
-question, but the syntax chosen was more Julian. This syntax-- as
-implemented for now -- does not nest. That is, it won't work with the
-outer vector in a vector of vectors, say. The parent `vec` should be a
-vector of replacement values only.
-
+question, but the syntax chosen was more Julian. This syntax -- as
+implemented for now -- does not allow for iteration. That is
+constructs like `{{#.[1]}}` don't introduce iteration, but only offer
+a conditional check.
 
 ### Partials
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,46 @@ end
 
 (A string is used -- and not a `mt` macro above -- so that string interpolation can happen.)
 
+### Iterating over vectors
+
+Iterating over an unnamed vector uses `{{.}}` to refer to the item:
+
+```
+tpl = "{{#:vec}}{{.}} {{/:vec}}"
+render(tpl, vec = ["A1", "B2", "C3"])  # "A1 B2 C3 "
+```
+
+Not the extra space after `C3`. There is *experimental* support for
+indexing with the iteration of a vector that allows on to work around
+this. The syntax `.[ind]` refers to the value `vec[ind]`.
+
+To print commas one can use this pattern:
+
+```
+tpl = "{{#:vec}}{{.}}{{^.[end]}}, {{/.[end]}}{{/:vec}}"
+render(tpl, vec = ["A1", "B2", "C3"])  # "A1, B2, C3"
+```
+
+To put the first value in bold, but no others, say:
+
+```
+tpl = """
+{{#:vec}}
+{{#.[1]}}<bold>{{.}}</bold>{{/.[1]}}
+{{^.[1]}}{{.}}{{/.[1]}}
+{{/:vec}}
+"""
+render(tpl, vec = ["A1", "B2", "C3"])  # "A1, B2, C3"
+```
+
+This was inspired by
+[this](http://stackoverflow.com/questions/11147373/only-show-the-first-item-in-list-using-mustache)
+question, but the syntax chosen was more Julian. This syntax-- as
+implemented for now -- does not nest. That is, it won't work with the
+outer vector in a vector of vectors, say. The parent `vec` should be a
+vector of replacement values only.
+
+
 ### Partials
 
 Partials are used to include partial templates into a template.

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -6,7 +6,7 @@ mtrender = render
 tpl = mt"the value of x is {{x}} and that of y is {{y}}"
 
 ## a dict
-out = mtrender(tpl, {"x"=>1, "y"=>2})
+out = mtrender(tpl, Dict("x"=>1, "y"=>2))
 println(out)
 
 ## A module
@@ -31,7 +31,7 @@ mtrender(tpl, Beta(1, 2))
 ## conditional text
 using Mustache
 tpl = "{{#b}}this doesn't show{{/b}}{{#a}}this does show{{/a}}"
-mtrender(tpl, {"a" => 1})
+mtrender(tpl, Dict("a" => 1))
 
 
 
@@ -54,7 +54,7 @@ for s in sort(map(string, names(m)))
 end
 
 using DataFrames
-d = DataFrame({"names" => _names, "summs" => _summaries})
+d = DataFrame(names = _names, summs = _summaries)
 
 tpl = "
 <html>
@@ -90,8 +90,8 @@ mtrender(tpl, d)
 ## array of Dicts
 using Mustache
 
-A = [{"a" => "eh", "b" => "bee"},
-     {"a" => "ah", "b" => "buh"}]
+A = [Dict("a" => "eh", "b" => "bee"),
+     Dict("a" => "ah", "b" => "buh")]
 
 ## Contrast to data frame:
 # D = DataFrame(quote
@@ -101,4 +101,13 @@ A = [{"a" => "eh", "b" => "bee"},
 
 tpl = mt"{{#A}} pronounce a as {{a}} and b as {{b}}.{{/A}}"
 
-mtrender(tpl, {"A" => A})
+mtrender(tpl, Dict("A" => A))
+
+
+## use .[ind] to index within a vector:
+
+tpl = mt"{{#:vec}}{{.[1]}}{{/:vec}}" # just first one
+mtrender(tpl, vec=["A1","B2","C3"])
+
+tpl = mt"{{#:vec}}{{.}}{{^.[end]}}, {{/.[end]}}{{/:vec}}" # serial commas
+mtrender(tpl, vec=["A1","B2","C3"])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
 include("Mustache_test.jl")
 include("multiple_nested_sections.jl")
+include("test_index.jl")
 #include("data-frame-test.jl")

--- a/test/test_index.jl
+++ b/test/test_index.jl
@@ -1,0 +1,14 @@
+## Experimental syntax for indexing within vectors:
+using Base.Test
+
+## use # to include
+tpl = mt"{{#:vec}}{{#.[1]}}{{.}}{{/.[1]}}{{/:vec}}"
+out = Mustache.render(tpl, vec=["A1","B2","C3"])
+@test out == "A1"
+
+## use ^ to exclude
+tpl = mt"{{#:vec}}{{.}}{{^.[end]}}, {{/.[end]}}{{/:vec}}"
+out = Mustache.render(tpl, vec=["A1","B2","C3"])
+@test out == "A1, B2, C3"
+
+


### PR DESCRIPTION
This introduces the `.[ind]` syntax when iterating over a vector. The `{{.}}` syntax is used to refer to the item in an iteration over the vector. The `.[ind]` can be used to refer to an item by index. This is envisioned to be useful when trying to do something for just the first, or last item, say. An example would be adding commas after each item but the last.