### PR TITLE
Make 0.7 work and fix deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 julia:
     - 0.4
     - 0.5
+    - 0.6
     - nightly
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - 0.4
-    - 0.5
     - 0.6
     - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.4
+julia 0.6
 Compat 0.7.18
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ environment:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/context.jl
+++ b/src/context.jl
@@ -1,7 +1,7 @@
 ## context
 
 ## A context stores objects where named values are looked up.
-type Context
+mutable struct Context
     view ## of what? a Dict, Module, CompositeKind, DataFrame.parent.
     parent ## a context or nothing
     _cache::Dict
@@ -19,7 +19,7 @@ end
 
 ## Lookup value by key in the context
 function lookup(ctx::Context, key)
-    
+
     if haskey(ctx._cache, key)
         value = ctx._cache[key]
     else
@@ -99,7 +99,7 @@ function _lookup_in_view(view::Dict, key)
 end
 
 function _lookup_in_view(view::Module, key)
-    
+
     hasmatch = false
     re = Regex("^$key\$")
     for i in names(view, true)
@@ -119,7 +119,7 @@ end
 
 ## Default is likely not great, but we use CompositeKind
 function _lookup_in_view(view, key)
-    nms = fieldnames(view)
+    nms = fieldnames(typeof(view))
     re = Regex(key)
     has_match = false
     for i in nms
@@ -136,4 +136,3 @@ function _lookup_in_view(view, key)
 
     out
 end
-

--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -1,6 +1,6 @@
 ## Scanner
 
-type Scanner
+mutable struct Scanner
     string::AbstractString
     tail::AbstractString
     pos::Integer
@@ -56,6 +56,3 @@ end
 
 scanUntil!(s::Scanner, re::AbstractString) = scanUntil!(s, Regex(re))
 scanUntil!(s::Scanner, re::Char) = scanUntil!(s, string(re))
-
-
-

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -15,7 +15,7 @@ function make_tokens(template, tags)
 
 
     tags = ["{{", "}}"]         # we hard code tags!
-    tagRes = [r"{{", r"}}"]   # escaped to be regular expressions
+    tagRes = [r"{{", r"}}"]
 
 
     scanner = Scanner(template)

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -1,8 +1,8 @@
-type MustacheTokens
+mutable struct MustacheTokens
     tokens
 end
 
-type AnIndex
+mutable struct AnIndex
     ind
     value
 end
@@ -15,7 +15,7 @@ function make_tokens(template, tags)
 
 
     tags = ["{{", "}}"]         # we hard code tags!
-    tagRes = ["\{\{", "\}\}"]   # escaped to be regular expressions
+    tagRes = [r"{{", r"}}"]   # escaped to be regular expressions
 
 
     scanner = Scanner(template)

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -1,6 +1,6 @@
 ## writer
 
-type Writer
+mutable struct Writer
     _cache::Dict
     _partialCache::Dict
     _loadPartial ## Function or nothing
@@ -52,4 +52,3 @@ function render(io::IO, w::Writer, template, view)
     f = compile(io, w, template, ["{{", "}}"])
     f(w, view)
 end
-

--- a/test/Mustache_test.jl
+++ b/test/Mustache_test.jl
@@ -5,7 +5,7 @@ tpl = mt"a:{{x}} b:{{{y}}}"
 
 x, y = "ex", "why"
 d = Dict("x"=>"ex", "y"=>"why")
-type ThrowAway
+mutable struct ThrowAway
     x
     y
 end
@@ -58,8 +58,8 @@ tpl = mt"""{{#wrapped}}
 
 d = Dict()
 d["name"] =  "Willy"
-d["wrapped"] = function() 
-    function(text, render) 
+d["wrapped"] = function()
+    function(text, render)
         "<b>" * render(text) * "</b>"
     end
     end

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -14,7 +14,7 @@ x = 1; y = "two"
 mtrender(tpl, Main)
 
 ## a CompositeKind
-type ThrowAway
+mutable struct ThrowAway
     x
     y
 end

--- a/test/multiple_nested_sections.jl
+++ b/test/multiple_nested_sections.jl
@@ -29,11 +29,11 @@ test_func = () -> render(failing_template,
 
 
 ## issue #31 -- nested sections
-type Location
+mutable struct Location
   lat::Float64
   lon::Float64
 end
-type Thing
+mutable struct Thing
   location::Location
   name::AbstractString
 end


### PR DESCRIPTION
The only error was this:

```julia
julia> "\{\{"
ERROR: syntax: invalid escape sequence
```

The rest of the changes are deprecations.

Naturally this will break 0.4 and 0.5, so if you still want to support those versions then `struct` just needs to be changed back to `type`. If you're okay with dropping them, then we'll just need to update `REQUIRE` to 0.6 and remove the tests from the CI files.