### PR TITLE
improve inverted section

### DIFF
--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -332,15 +332,15 @@ function renderTokens(io, tokens, writer, context, template)
             value = lookup(context, tokenValue)
             if !isa(value, AnIndex)
                 context = Context(value, context)
+
+                if falsy(value)
+                    renderTokensByValue(value, io, token, writer, context, template)
+                end
+            else
+                # for indices falsy test is performed in
+                # _renderTokensByValue(value::AnIndex,...)
+                renderTokensByValue(value, io, token, writer, context, template)
             end
-
-            #context = Context(value, context) # <<<
-            renderTokensByValue(value, io, token, writer, context, template)
-
-#            if falsy(value)
-#                renderTokens(io, token[5], writer, context, template)
-#            end
-
 
         elseif token[1] == ">"
             ## partials

--- a/test/Mustache_test.jl
+++ b/test/Mustache_test.jl
@@ -73,3 +73,4 @@ d = Dict(); d["x"] = "salt"; d["y"] = "pepper"
 
 ## issue #51 inverted section
 @test Mustache.render("""{{^repos}}No repos :({{/repos}}""", Dict("repos" => [])) == "No repos :("    
+@test Mustache.render("{{^repos}}foo{{/repos}}",Dict("repos" => [Dict("name" => "repo name")])) == ""


### PR DESCRIPTION
This PR addresses the issue that to following is not empty is current version of Mustache

```julia
Mustache.render("{{^repos}}foo{{/repos}}",Dict("repos" => [Dict("name" => "repo name")]))
```