### PR TITLE
adjustments to handle spec; close #64, close #47

### DIFF
--- a/src/Mustache.jl
+++ b/src/Mustache.jl
@@ -27,6 +27,7 @@ macro mt_mstr(s)
 end
 
 """
+    render([io], tokens, view)
 
 Render a set of tokens with a view, using optional `io` object to print or store.
 

--- a/src/context.jl
+++ b/src/context.jl
@@ -54,13 +54,15 @@ function lookup(ctx::Context, key)
                 idx = m.captures[1]
                 vals = context.parent.view
 
-                if isa(vals, Vector)
-                    if idx == "end"
-                        value = AnIndex(-1, vals[end])
-                    else
-                        ind = Base.parse(Int, idx[1:end])
-                        value = AnIndex(ind, vals[ind])
-                    end
+                # this has limited support for indices: "end", or a number, but no
+                # arithmetic, such as `end-1`.
+                if isa(vals, Vector) # supports getindex(v, i)?
+                   if idx == "end"
+                       value = AnIndex(-1, vals[end])
+                   else
+                       ind = Base.parse(Int, idx) 
+                       value = AnIndex(ind, vals[ind])
+                   end
                     break
                 end
             else

--- a/src/context.jl
+++ b/src/context.jl
@@ -56,7 +56,7 @@ function lookup(ctx::Context, key)
 
                 if isa(vals, Vector)
                     if idx == "end"
-                        value = AnIndex(:end, vals[end])
+                        value = AnIndex(-1, vals[end])
                     else
                         ind = Base.parse(Int, idx[1:end])
                         value = AnIndex(ind, vals[ind])
@@ -76,10 +76,7 @@ function lookup(ctx::Context, key)
         ctx._cache[key] = value
     end
 
-    if value === Function
-        value = value()
-    end
-
+   
     return(value)
 end
 
@@ -102,18 +99,13 @@ end
 
 
 function _lookup_in_view(view::Dict, key)
-
     ## is it a symbol?
     if occursin(r"^:", key)
         key = Symbol(key[2:end])
     end
+    
+    get(view, key, nothing)
 
-    out = nothing
-    if haskey(view, key)
-        out = view[key]
-    end
-
-    out
 end
 
 function _lookup_in_view(view::Module, key)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -4,7 +4,6 @@
 function parse(template, tags)
 
     tokens = make_tokens(template, tags)
-    tokens = squashTokens(tokens)
     out = nestTokens(tokens)
     ##out
     MustacheTokens(out)

--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -1,8 +1,8 @@
 ## Scanner
 
 mutable struct Scanner
-    string::AbstractString
-    tail::AbstractString
+    string::String
+    tail::String
     pos::Integer
 end
 Scanner(string::AbstractString) = Scanner("", string, 0)
@@ -17,12 +17,13 @@ end
 
 ## Tries to match the given regular expression at the current position.
 ## Returns the matched text if it can match, the empty string otherwise.
-function scan(s::Scanner, re::Regex)
-    if !occursin(re, s.tail)
-        return ""
-    end
+function scan!(s::Scanner, re::Regex)
 
     m = match(re, s.tail)
+    if m == nothing
+        return  ""
+    end
+    
     if m.offset >= 1
         ## move past match
         no_chars = lastindex(m.match) + m.offset - 1
@@ -32,14 +33,14 @@ function scan(s::Scanner, re::Regex)
 
     m.match
 end
-scan(s::Scanner, re::AbstractString) = scan(s, Regex(re))
-scan(s::Scanner, re::Char) = scan(s, string(re))
+scan!(s::Scanner, re::AbstractString) = scan!(s, Regex(re))
+scan!(s::Scanner, re::Char) = scan!(s, string(re))
 
 ## Skips all text until the given regular expression can be matched. Returns
 ## the skipped string, which is the entire tail if no match can be made.
 function scanUntil!(s::Scanner, re::Regex)
     m = match(re, s.tail)
-           
+    
     if m == nothing
         ourmatch = s.tail
         s.pos += lastindex(s.tail)
@@ -48,6 +49,9 @@ function scanUntil!(s::Scanner, re::Regex)
         pos = m.offset
         j = prevind(s.tail, pos)
         k = nextind(s.tail, pos-1)
+
+#        println((pos, s.tail, s.tail[1:j], s.tail[k:lastindex(s.tail)]))
+        
         ourmatch = s.tail[1:j]
         s.tail = s.tail[k:lastindex(s.tail)]
         s.pos += pos

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,6 +21,7 @@ falsy(x::Bool) = !x
 falsy(x::Array) = isempty(x)
 falsy(x::AbstractString) = x == ""
 falsy(x::Nothing) = true
+falsy(x::Missing) = true
 falsy(x::Real) = x == 0
 falsy(x) = (x == nothing) || false                #  default
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,7 +5,16 @@ nonSpaceRe = r"\S"
 eqRe = r"\s*="
 curlyRe = r"\s*\}"
 #tagRe = r"#|\^|\/|>|\{|&|=|!"
-tagRe = r"^[#^/<>{&=!]"
+# # section
+# ^ inversion
+# / close section
+# > partials
+# { dont' escape
+# &
+# =
+# !
+# | lamda "section" with *evaluated* value
+tagRe = r"^[#^/<>{&=!|]"
 
 
 isWhitespace(x) = occursin(whiteRe, x)

--- a/test/Mustache_test.jl
+++ b/test/Mustache_test.jl
@@ -52,19 +52,12 @@ tpl = mt"{{#:vec}}{{.}} {{/:vec}}"
 ## test of function, see http://mustache.github.io/mustache.5.html (Lambdas)
 
 tpl = mt"""{{#wrapped}}
-  {{name}} is awesome.
+{{name}} is awesome.
 {{/wrapped}}
 """
 
-d = Dict()
-d["name"] =  "Willy"
-d["wrapped"] = function()
-    function(text, render)
-        "<b>" * render(text) * "</b>"
-    end
-    end
-
-@test Mustache.render(tpl, d) == "<b>\n  Willy is awesome.\n</b>\n" #?? extra \n??
+d = Dict("name" => "Willy", "wrapped" => (txt) -> "<b>" * txt * "</b>")
+@test Mustache.render(tpl, d) == "<b>Willy is awesome.\n</b>"
 
 ## Test of using Dict in {{#}}/{{/}} things
 tpl = mt"{{#:d}}{{x}} and {{y}}{{/:d}}"

--- a/test/Mustache_test.jl
+++ b/test/Mustache_test.jl
@@ -67,3 +67,17 @@ d = Dict(); d["x"] = "salt"; d["y"] = "pepper"
 ## issue #51 inverted section
 @test Mustache.render("""{{^repos}}No repos :({{/repos}}""", Dict("repos" => [])) == "No repos :("    
 @test Mustache.render("{{^repos}}foo{{/repos}}",Dict("repos" => [Dict("name" => "repo name")])) == ""
+
+
+## Added a new tag "|" for applying a function to a section
+tpl = """{{|lambda}}{{value}}{{/lambda}} dollars."""
+d = Dict("value"=>"1.23456789", "lambda"=>(txt) -> "<b>" * string(round(parse(Float64, txt), digits=2)) * "</b>")
+@test Mustache.render(tpl, d) == "<b>1.23</b> dollars."
+
+tpl = """{{|lambda}}key{{/lambda}} dollars."""
+d = Dict("lambda" => (txt) -> begin
+         d = Dict("key" => "value")
+         d[txt]
+         end
+         )
+@test Mustache.render(tpl, d) == "value dollars."

--- a/test/mustache_specs.jl
+++ b/test/mustache_specs.jl
@@ -7,7 +7,7 @@ using Test
 ghub = "https://raw.githubusercontent.com/mustache/spec/72233f3ffda9e33915fd3022d0a9ebbcce265acd/specs/{{:spec}}.yml"
 
 specs = ["comments",
-          "$delimiters",
+          "delimiters",
           "interpolation",
           "inverted",
           "partials",
@@ -23,16 +23,11 @@ for spec in specs
 end
 
 
-
-strip_rns(x) = replace(replace(replace(x, "\n"=>""), "\r"=>""), r"\s"=>"")
-
-
 function write_spec_file(fname)
     io = open("spec_$fname.jl","w")
     println(io, """
 using Mustache
 using Test
-strip_rns(x) = replace(replace(replace(x, "\\n"=>""), "\\r"=>""), r"\\s"=>"")
 """)        
     
     x = D[fname]
@@ -62,20 +57,7 @@ strip_rns(x) = replace(replace(replace(x, "\\n"=>""), "\\r"=>""), r"\\s"=>"")
         print(io, "tpl = \"\"\"")
         print(io, tpl)
         println(io, "\"\"\"\n")
-        if  val ==  expected
-            println(io, "\t@test Mustache.render(tpl, $data) == $expected_")
-        else
-            if strip_rns(val) == strip_rns(expected)
-                #println("Test failed: $fname, test $i <-- space issue")
-                println(io, "\t## XXX space issue")
-                println(io, "\tval = strip_rns(Mustache.render(tpl, $data))")
-                println(io, "\texpected = strip_rns($expected_)")
-                println(io, "\t@test val == expected")
-                
-            elseif val == "Failed"
-                print(io, "\t@test_skip Mustache.render(tpl, $data) == $expected_\n")
-            end
-        end
+        println(io, "\t@test Mustache.render(tpl, $data) == $expected_")
         println("")
     end
     println(io, "end\n\n")
@@ -83,4 +65,39 @@ strip_rns(x) = replace(replace(replace(x, "\\n"=>""), "\\r"=>""), r"\\s"=>"")
 end
 
 
-for spec in 
+for spec in specs
+    write_spec_file(spec)
+end
+
+
+# partials are different, as they refer to an external file
+# XXX fix tests 7,8,9,10 for space issues.
+using Test
+function test_partials()
+    for (i,t) in enumerate(D["partials"]["tests"])
+
+        println("Test $i...")
+        
+        d = t["data"]
+        partial = t["partials"]
+        for (k,v) in partial
+            io = open(k, "w")
+            write(io, v)
+            close(io)
+        end
+        
+        tpl = t["template"]
+        expected = t["expected"]
+
+        if !(i in (7,8, 9, 10)) # failed tests...
+            @test Mustache.render(tpl, d) == expected
+        end
+
+        for (k,v) in partial
+            rm(k)
+        end
+    end
+end
+        
+
+        

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,6 @@ include("spec_comments.jl")
 #include("spec_delimiters.jl") # not implemented
 include("spec_interpolation.jl")
 include("spec_inverted.jl")
-include("spec_partials.jl")
+#include("spec_partials.jl") # need separate writing
 include("spec_sections.jl")
-
+include("spec_lambdas.jl")

--- a/test/spec_comments.jl
+++ b/test/spec_comments.jl
@@ -1,6 +1,5 @@
 using Mustache
 using Test
-strip_rns(x) = replace(replace(replace(x, "\n"=>""), "\r"=>""), r"\s"=>"")
 
 @testset " comments " begin
 
@@ -26,12 +25,9 @@ tpl = """Begin.
 End.
 """
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}()))
-	expected = strip_rns("""Begin.
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """Begin.
 End.
-""")
-	@test val == expected
+"""
 
 	## All standalone comment lines should be removed.
 tpl = """Begin.
@@ -39,42 +35,30 @@ tpl = """Begin.
 End.
 """
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}()))
-	expected = strip_rns("""Begin.
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """Begin.
 End.
-""")
-	@test val == expected
+"""
 
 	## "\r\n" should be considered a newline for standalone tags.
 tpl = """|
 {{! Standalone Comment }}
 |"""
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}()))
-	expected = strip_rns("""|
-|""")
-	@test val == expected
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """|
+|"""
 
 	## Standalone tags should not require a newline to precede them.
 tpl = """  {{! I'm Still Standalone }}
 !"""
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}()))
-	expected = strip_rns("""!""")
-	@test val == expected
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """!"""
 
 	## Standalone tags should not require a newline to follow them.
 tpl = """!
   {{! I'm Still Standalone }}"""
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}()))
-	expected = strip_rns("""!
-""")
-	@test val == expected
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """!
+"""
 
 	## All standalone comment lines should be removed.
 tpl = """Begin.
@@ -84,27 +68,21 @@ Something's going on here...
 End.
 """
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}()))
-	expected = strip_rns("""Begin.
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """Begin.
 End.
-""")
-	@test val == expected
+"""
 
 	## All standalone comment lines should be removed.
 tpl = """Begin.
-  {{!
+  {{!s
     Something's going on here...
   }}
 End.
 """
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}()))
-	expected = strip_rns("""Begin.
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """Begin.
 End.
-""")
-	@test val == expected
+"""
 
 	## Inline comments should not strip whitespace
 tpl = """  12 {{! 34 }}

--- a/test/spec_delimiters.jl
+++ b/test/spec_delimiters.jl
@@ -1,6 +1,5 @@
 using Mustache
 using Test
-strip_rns(x) = replace(replace(replace(x, "\n"=>""), "\r"=>""), r"\s"=>"")
 
 @testset " delimiters " begin
 
@@ -8,10 +7,12 @@ strip_rns(x) = replace(replace(replace(x, "\n"=>""), "\r"=>""), r"\s"=>"")
 	## The equals sign (used on both sides) should permit delimiter changes.
 tpl = """{{=<% %>=}}(<%text%>)"""
 
+	@test Mustache.render(tpl, Dict{Any,Any}("text"=>"Hey!")) == """(Hey!)"""
 
 	## Characters with special meaning regexen should be valid delimiters.
 tpl = """({{=[ ]=}}[text])"""
 
+	@test Mustache.render(tpl, Dict{Any,Any}("text"=>"It worked!")) == """(It worked!)"""
 
 	## Delimiters set outside sections should persist.
 tpl = """[
@@ -28,7 +29,7 @@ tpl = """[
 ]
 """
 
-	@test_skip Mustache.render(tpl, Dict{Any,Any}("section"=>true,"data"=>"I got interpolated.")) == """[
+	@test Mustache.render(tpl, Dict{Any,Any}("section"=>true,"data"=>"I got interpolated.")) == """[
   I got interpolated.
   |data|
 
@@ -52,7 +53,7 @@ tpl = """[
 ]
 """
 
-	@test_skip Mustache.render(tpl, Dict{Any,Any}("section"=>false,"data"=>"I got interpolated.")) == """[
+	@test Mustache.render(tpl, Dict{Any,Any}("section"=>false,"data"=>"I got interpolated.")) == """[
   I got interpolated.
   |data|
 
@@ -67,7 +68,7 @@ tpl = """[ {{>include}} ]
 [ |>include| ]
 """
 
-	@test_skip Mustache.render(tpl, Dict{Any,Any}("value"=>"yes")) == """[ .yes. ]
+	@test Mustache.render(tpl, Dict{Any,Any}("value"=>"yes")) == """[ .yes. ]
 [ .yes. ]
 """
 
@@ -76,6 +77,9 @@ tpl = """[ {{>include}} ]
 [ .{{value}}.  .|value|. ]
 """
 
+	@test Mustache.render(tpl, Dict{Any,Any}("value"=>"yes")) == """[ .yes.  .yes. ]
+[ .yes.  .|value|. ]
+"""
 
 	## Surrounding whitespace should be left untouched.
 tpl = """| {{=@ @=}} |"""
@@ -95,12 +99,9 @@ tpl = """Begin.
 End.
 """
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}()))
-	expected = strip_rns("""Begin.
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """Begin.
 End.
-""")
-	@test val == expected
+"""
 
 	## Indented standalone lines should be removed from the template.
 tpl = """Begin.
@@ -108,44 +109,35 @@ tpl = """Begin.
 End.
 """
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}()))
-	expected = strip_rns("""Begin.
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """Begin.
 End.
-""")
-	@test val == expected
+"""
 
 	## "\r\n" should be considered a newline for standalone tags.
 tpl = """|
 {{= @ @ =}}
 |"""
 
-	@test_skip Mustache.render(tpl, Dict{Any,Any}()) == """|
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """|
 |"""
 
 	## Standalone tags should not require a newline to precede them.
 tpl = """  {{=@ @=}}
 ="""
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}()))
-	expected = strip_rns("""=""")
-	@test val == expected
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """="""
 
 	## Standalone tags should not require a newline to follow them.
 tpl = """=
   {{=@ @=}}"""
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}()))
-	expected = strip_rns("""=
-""")
-	@test val == expected
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """=
+"""
 
 	## Superfluous in-tag whitespace should be ignored.
 tpl = """|{{= @   @ =}}|"""
 
-	@test_skip Mustache.render(tpl, Dict{Any,Any}()) == """||"""
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """||"""
 end
 
 

--- a/test/spec_interpolation.jl
+++ b/test/spec_interpolation.jl
@@ -1,6 +1,5 @@
 using Mustache
 using Test
-strip_rns(x) = replace(replace(replace(x, "\n"=>""), "\r"=>""), r"\s"=>"")
 
 @testset " interpolation " begin
 

--- a/test/spec_inverted.jl
+++ b/test/spec_inverted.jl
@@ -1,6 +1,5 @@
 using Mustache
 using Test
-strip_rns(x) = replace(replace(replace(x, "\n"=>""), "\r"=>""), r"\s"=>"")
 
 @testset " inverted " begin
 
@@ -40,13 +39,10 @@ tpl = """{{^bool}}
 {{/bool}}
 """
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}("two"=>"second","bool"=>false)))
-	expected = strip_rns("""* first
+	@test Mustache.render(tpl, Dict{Any,Any}("two"=>"second","bool"=>false)) == """* first
 * second
 * third
-""")
-	@test val == expected
+"""
 
 	## Nested falsey sections should have their contents rendered.
 tpl = """| A {{^bool}}B {{^bool}}C{{/bool}} D{{/bool}} E |"""
@@ -111,13 +107,10 @@ tpl = """| This Is
 | A Line
 """
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)))
-	expected = strip_rns("""| This Is
+	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)) == """| This Is
 |
 | A Line
-""")
-	@test val == expected
+"""
 
 	## Standalone indented lines should be removed from the template.
 tpl = """| This Is
@@ -127,13 +120,10 @@ tpl = """| This Is
 | A Line
 """
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)))
-	expected = strip_rns("""| This Is
+	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)) == """| This Is
 |
 | A Line
-""")
-	@test val == expected
+"""
 
 	## "\r\n" should be considered a newline for standalone tags.
 tpl = """|
@@ -141,34 +131,25 @@ tpl = """|
 {{/boolean}}
 |"""
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)))
-	expected = strip_rns("""|
-|""")
-	@test val == expected
+	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)) == """|
+|"""
 
 	## Standalone tags should not require a newline to precede them.
 tpl = """  {{^boolean}}
 ^{{/boolean}}
 /"""
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)))
-	expected = strip_rns("""^
-/""")
-	@test val == expected
+	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)) == """^
+/"""
 
 	## Standalone tags should not require a newline to follow them.
 tpl = """^{{^boolean}}
 /
   {{/boolean}}"""
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)))
-	expected = strip_rns("""^
+	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)) == """^
 /
-""")
-	@test val == expected
+"""
 
 	## Superfluous in-tag whitespace should be ignored.
 tpl = """|{{^ boolean }}={{/ boolean }}|"""

--- a/test/spec_lambdas.jl
+++ b/test/spec_lambdas.jl
@@ -1,0 +1,214 @@
+using Mustache
+using Test
+
+mutable struct CallableFunction <: Function
+  calls::Int
+end
+(F::CallableFunction)() = (F.calls += 1; string(F.calls))
+
+@testset " lambdas " begin
+# overview: |
+#   Lambdas are a special-cased data type for use in interpolations and
+#   sections.
+
+#   When used as the data value for an Interpolation tag, the lambda MUST be
+#   treatable as an arity 0 function, and invoked as such.  The returned value
+#   MUST be rendered against the default delimiters, then interpolated in place
+#   of the lambda.
+
+#   When used as the data value for a Section tag, the lambda MUST be treatable
+#   as an arity 1 function, and invoked as such (passing a String containing the
+#   unprocessed section contents).  The returned value MUST be rendered against
+#   the current delimiters, then interpolated in place of the section.
+# tests:
+#   - name: Interpolation
+#     desc: A lambda's return value should be interpolated.
+#     data:
+#       lambda: !code
+#         ruby:    'proc { "world" }'
+#         perl:    'sub { "world" }'
+#         js:      'function() { return "world" }'
+#         php:     'return "world";'
+#         python:  'lambda: "world"'
+#         clojure: '(fn [] "world")'
+#     template: "Hello, {{lambda}}!"
+#     expected: "Hello, world!"
+
+    template = "Hello, {{lambda}}!"
+    expected = "Hello, world!"
+    data = Dict("lambda"=> () -> "world")
+    @test Mustache.render(template, data) == expected
+
+
+
+#   - name: Interpolation - Expansion
+#     desc: A lambda's return value should be parsed.
+#     data:
+#       planet: "world"
+#       lambda: !code
+#         ruby:    'proc { "{{planet}}" }'
+#         perl:    'sub { "{{planet}}" }'
+#         js:      'function() { return "{{planet}}" }'
+#         php:     'return "{{planet}}";'
+#         python:  'lambda: "{{planet}}"'
+#         clojure: '(fn [] "{{planet}}")'
+#     template: "Hello, {{lambda}}!"
+#     expected: "Hello, world!"
+
+    template = "Hello, {{lambda}}!"
+    expected = "Hello, world!"
+    data = Dict("lambda" => () -> "{{planet}}", "planet" => "world")
+    @test Mustache.render(template, data) == expected
+    
+#   - name: Interpolation - Alternate Delimiters
+#     desc: A lambda's return value should parse with the default delimiters.
+#     data:
+#       planet: "world"
+#       lambda: !code
+#         ruby:    'proc { "|planet| => {{planet}}" }'
+#         perl:    'sub { "|planet| => {{planet}}" }'
+#         js:      'function() { return "|planet| => {{planet}}" }'
+#         php:     'return "|planet| => {{planet}}";'
+#         python:  'lambda: "|planet| => {{planet}}"'
+#         clojure: '(fn [] "|planet| => {{planet}}")'
+#     template: "{{= | | =}}\nHello, (|&lambda|)!"
+#     expected: "Hello, (|planet| => world)!"
+
+    template = "{{= | | =}}\nHello, (|&lambda|)!"
+    expected = "Hello, (|planet| => world)!"
+    data = Dict("planet"=>"world", "lambda"=> () -> "|planet| => {{planet}}")
+    @test_skip Mustache.render(template, data) == expected
+    
+#   - name: Interpolation - Multiple Calls
+#     desc: Interpolated lambdas should not be cached.
+#     data:
+#       lambda: !code
+#         ruby:    'proc { $calls ||= 0; $calls += 1 }'
+#         perl:    'sub { no strict; $calls += 1 }'
+#         js:      'function() { return (g=(function(){return this})()).calls=(g.calls||0)+1 }'
+#         php:     'global $calls; return ++$calls;'
+#         python:  'lambda: globals().update(calls=globals().get("calls",0)+1) or calls'
+#         clojure: '(def g (atom 0)) (fn [] (swap! g inc))'
+#     template: '{{lambda}} == {{{lambda}}} == {{lambda}}'
+#     expected: '1 == 2 == 3'
+
+    template = "{{lambda}} == {{{lambda}}} == {{lambda}}"
+    expected =  "1 == 2 == 3"
+    data = Dict("lambda" => CallableFunction(0))
+    @test Mustache.render(template, data) == expected
+    
+#   - name: Escaping
+#     desc: Lambda results should be appropriately escaped.
+#     data:
+#       lambda: !code
+#         ruby:    'proc { ">" }'
+#         perl:    'sub { ">" }'
+#         js:      'function() { return ">" }'
+#         php:     'return ">";'
+#         python:  'lambda: ">"'
+#         clojure: '(fn [] ">")'
+#     template: "<{{lambda}}{{{lambda}}}"
+#     expected: "<&gt;>"
+
+
+    template = "<{{lambda}}{{{lambda}}}"
+    expected = "<&gt;>"
+    data = Dict("lambda" => () -> ">")
+    @test Mustache.render(template, data) == expected
+    
+#   - name: Section
+#     desc: Lambdas used for sections should receive the raw section string.
+#     data:
+#       x: 'Error!'
+#       lambda: !code
+#         ruby:    'proc { |text| text == "{{x}}" ? "yes" : "no" }'
+#         perl:    'sub { $_[0] eq "{{x}}" ? "yes" : "no" }'
+#         js:      'function(txt) { return (txt == "{{x}}" ? "yes" : "no") }'
+#         php:     'return ($text == "{{x}}") ? "yes" : "no";'
+#         python:  'lambda text: text == "{{x}}" and "yes" or "no"'
+#         clojure: '(fn [text] (if (= text "{{x}}") "yes" "no"))'
+#     template: "<{{#lambda}}{{x}}{{/lambda}}>"
+#     expected: "<yes>"
+
+    template = "<{{#lambda}}{{x}}{{/lambda}}>"
+    expected = "<yes>"
+    data = Dict("x" => "Error!", "lambda" => (txt) ->  txt == "{{x}}" ? "yes" : "no")
+    @test Mustache.render(template, data) == expected
+    
+#   - name: Section - Expansion
+#     desc: Lambdas used for sections should have their results parsed.
+#     data:
+#       planet: "Earth"
+#       lambda: !code
+#         ruby:    'proc { |text| "#{text}{{planet}}#{text}" }'
+#         perl:    'sub { $_[0] . "{{planet}}" . $_[0] }'
+#         js:      'function(txt) { return txt + "{{planet}}" + txt }'
+#         php:     'return $text . "{{planet}}" . $text;'
+#         python:  'lambda text: "%s{{planet}}%s" % (text, text)'
+#         clojure: '(fn [text] (str text "{{planet}}" text))'
+#     template: "<{{#lambda}}-{{/lambda}}>"
+#     expected: "<-Earth->"
+
+    template = "<{{#lambda}}-{{/lambda}}>"
+    expected = "<-Earth->"
+    data = Dict("planet"=> "Earth", "lambda" => (txt) -> txt * "{{planet}}" * txt)
+    @test Mustache.render(template, data) == expected
+
+#   - name: Section - Alternate Delimiters
+#     desc: Lambdas used for sections should parse with the current delimiters.
+#     data:
+#       planet: "Earth"
+#       lambda: !code
+#         ruby:    'proc { |text| "#{text}{{planet}} => |planet|#{text}" }'
+#         perl:    'sub { $_[0] . "{{planet}} => |planet|" . $_[0] }'
+#         js:      'function(txt) { return txt + "{{planet}} => |planet|" + txt }'
+#         php:     'return $text . "{{planet}} => |planet|" . $text;'
+#         python:  'lambda text: "%s{{planet}} => |planet|%s" % (text, text)'
+#         clojure: '(fn [text] (str text "{{planet}} => |planet|" text))'
+#     template: "{{= | | =}}<|#lambda|-|/lambda|>"
+#     expected: "<-{{planet}} => Earth->"
+
+template = "{{= | | =}}<|#lambda|-|/lambda|>"
+expected =  "<-{{planet}} => Earth->"
+data = Dict("planet"=>"Earth", "lambda"=> (txt) -> txt * "{{planet}} => |planet|" * txt)
+@test_skip Mustache.render(template, data) == expected
+
+#   - name: Section - Multiple Calls
+#     desc: Lambdas used for sections should not be cached.
+#     data:
+#       lambda: !code
+#         ruby:    'proc { |text| "__#{text}__" }'
+#         perl:    'sub { "__" . $_[0] . "__" }'
+#         js:      'function(txt) { return "__" + txt + "__" }'
+#         php:     'return "__" . $text . "__";'
+#         python:  'lambda text: "__%s__" % (text)'
+#         clojure: '(fn [text] (str "__" text "__"))'
+#     template: '{{#lambda}}FILE{{/lambda}} != {{#lambda}}LINE{{/lambda}}'
+#     expected: '__FILE__ != __LINE__'
+
+ template = "{{#lambda}}FILE{{/lambda}} != {{#lambda}}LINE{{/lambda}}"
+expected = "__FILE__ != __LINE__"
+data = Dict("lambda" => (txt) ->  "__" * txt * "__")
+@test Mustache.render(template, data) == expected
+            
+
+#   - name: Inverted Section
+#     desc: Lambdas used for inverted sections should be considered truthy.
+#     data:
+#       static: 'static'
+#       lambda: !code
+#         ruby:    'proc { |text| false }'
+#         perl:    'sub { 0 }'
+#         js:      'function(txt) { return false }'
+#         php:     'return false;'
+#         python:  'lambda text: 0'
+#         clojure: '(fn [text] false)'
+#     template: "<{{^lambda}}{{static}}{{/lambda}}>"
+#     expected: "<>"
+
+ template = "<{{^lambda}}{{static}}{{/lambda}}>"
+expected = "<>"
+data = Dict("static" => "static", "lambda" => (txt) -> false)
+@test Mustache.render(template, data) == expected
+
+end

--- a/test/spec_partials.jl
+++ b/test/spec_partials.jl
@@ -1,6 +1,5 @@
 using Mustache
 using Test
-strip_rns(x) = replace(replace(replace(x, "\n"=>""), "\r"=>""), r"\s"=>"")
 
 @testset " partials " begin
 
@@ -8,6 +7,7 @@ strip_rns(x) = replace(replace(replace(x, "\n"=>""), "\r"=>""), r"\s"=>"")
 	## The greater-than operator should expand to the named partial.
 tpl = """\"{{>text}}\""""
 
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """\"from partial\""""
 
 	## The empty string should be used when the named partial is not found.
 tpl = """\"{{>text}}\""""
@@ -17,35 +17,48 @@ tpl = """\"{{>text}}\""""
 	## The greater-than operator should operate within the current context.
 tpl = """\"{{>partial}}\""""
 
+	@test Mustache.render(tpl, Dict{Any,Any}("text"=>"content")) == """\"*content*\""""
 
 	## The greater-than operator should properly recurse.
 tpl = """{{>node}}"""
 
+	@test Mustache.render(tpl, Dict{Any,Any}("nodes"=>Dict{Any,Any}[Dict("nodes"=>Any[],"content"=>"Y")],"content"=>"X")) == """X<Y<>>"""
 
 	## The greater-than operator should not alter surrounding whitespace.
 tpl = """| {{>partial}} |"""
 
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """| 	|	 |"""
 
 	## Whitespace should be left untouched.
 tpl = """  {{data}}  {{> partial}}
 """
 
+	@test Mustache.render(tpl, Dict{Any,Any}("data"=>"|")) == """  |  >
+>
+"""
 
 	## "\r\n" should be considered a newline for standalone tags.
 tpl = """|
 {{>partial}}
 |"""
 
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """|
+>|"""
 
 	## Standalone tags should not require a newline to precede them.
 tpl = """  {{>partial}}
 >"""
 
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """  >
+  >>"""
 
 	## Standalone tags should not require a newline to follow them.
 tpl = """>
   {{>partial}}"""
 
+	@test Mustache.render(tpl, Dict{Any,Any}()) == """>
+  >
+  >"""
 
 	## Each line of the partial should be indented before rendering.
 tpl = """\\
@@ -53,10 +66,18 @@ tpl = """\\
 /
 """
 
+	@test Mustache.render(tpl, Dict{Any,Any}("content"=>"<\n->")) == """\\
+ |
+ <
+->
+ |
+/
+"""
 
 	## Superfluous in-tag whitespace should be ignored.
 tpl = """|{{> partial }}|"""
 
+	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>true)) == """|[]|"""
 end
 
 

--- a/test/spec_sections.jl
+++ b/test/spec_sections.jl
@@ -1,6 +1,5 @@
 using Mustache
 using Test
-strip_rns(x) = replace(replace(replace(x, "\n"=>""), "\r"=>""), r"\s"=>"")
 
 @testset " sections " begin
 
@@ -42,9 +41,7 @@ tpl = """{{#a}}
 {{/a}}
 """
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}("c"=>Dict{Any,Any}("three"=>3),"e"=>Dict{Any,Any}("five"=>5),"b"=>Dict{Any,Any}("two"=>2),"a"=>Dict{Any,Any}("one"=>1),"d"=>Dict{Any,Any}("four"=>4))))
-	expected = strip_rns("""1
+	@test Mustache.render(tpl, Dict{Any,Any}("c"=>Dict{Any,Any}("three"=>3),"e"=>Dict{Any,Any}("five"=>5),"b"=>Dict{Any,Any}("two"=>2),"a"=>Dict{Any,Any}("one"=>1),"d"=>Dict{Any,Any}("four"=>4))) == """1
 121
 12321
 1234321
@@ -53,8 +50,7 @@ tpl = """{{#a}}
 12321
 121
 1
-""")
-	@test val == expected
+"""
 
 	## Lists should be iterated; list items should visit the context stack.
 tpl = """\"{{#list}}{{item}}{{/list}}\""""
@@ -76,13 +72,10 @@ tpl = """{{#bool}}
 {{/bool}}
 """
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}("two"=>"second","bool"=>true)))
-	expected = strip_rns("""* first
+	@test Mustache.render(tpl, Dict{Any,Any}("two"=>"second","bool"=>true)) == """* first
 * second
 * third
-""")
-	@test val == expected
+"""
 
 	## Nested truthy sections should have their contents rendered.
 tpl = """| A {{#bool}}B {{#bool}}C{{/bool}} D{{/bool}} E |"""
@@ -162,13 +155,10 @@ tpl = """| This Is
 | A Line
 """
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}("boolean"=>true)))
-	expected = strip_rns("""| This Is
+	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>true)) == """| This Is
 |
 | A Line
-""")
-	@test val == expected
+"""
 
 	## Indented standalone lines should be removed from the template.
 tpl = """| This Is
@@ -178,13 +168,10 @@ tpl = """| This Is
 | A Line
 """
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}("boolean"=>true)))
-	expected = strip_rns("""| This Is
+	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>true)) == """| This Is
 |
 | A Line
-""")
-	@test val == expected
+"""
 
 	## "\r\n" should be considered a newline for standalone tags.
 tpl = """|
@@ -192,34 +179,25 @@ tpl = """|
 {{/boolean}}
 |"""
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}("boolean"=>true)))
-	expected = strip_rns("""|
-|""")
-	@test val == expected
+	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>true)) == """|
+|"""
 
 	## Standalone tags should not require a newline to precede them.
 tpl = """  {{#boolean}}
 #{{/boolean}}
 /"""
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}("boolean"=>true)))
-	expected = strip_rns("""#
-/""")
-	@test val == expected
+	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>true)) == """#
+/"""
 
 	## Standalone tags should not require a newline to follow them.
 tpl = """#{{#boolean}}
 /
   {{/boolean}}"""
 
-	## XXX space issue
-	val = strip_rns(Mustache.render(tpl, Dict{Any,Any}("boolean"=>true)))
-	expected = strip_rns("""#
+	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>true)) == """#
 /
-""")
-	@test val == expected
+"""
 
 	## Superfluous in-tag whitespace should be ignored.
 tpl = """|{{# boolean }}={{/ boolean }}|"""


### PR DESCRIPTION
Big overhaul of the token parsing code:

* fixes tests for space issues with standalone tags (#64, #47)
* fixes tests for partials (these are not run in testsuite though)
* adds tests for lambdas
* speedups

