### PR TITLE
NamedTuples as views

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -110,6 +110,20 @@ function _lookup_in_view(view::AbstractDict, key)
 
 end
 
+
+function _lookup_in_view(view::NamedTuple, key)
+    ## is it a symbol?
+    if occursin(r"^:", key)
+        key = Symbol(key[2:end])
+    end
+
+    if haskey(view, key)
+        getindex(view, key)
+    else
+        nothing
+    end
+end
+
 function _lookup_in_view(view::Module, key)
 
     hasmatch = false

--- a/test/Mustache_test.jl
+++ b/test/Mustache_test.jl
@@ -65,7 +65,7 @@ d = Dict(); d["x"] = "salt"; d["y"] = "pepper"
 @test Mustache.render(tpl, d=d) == "salt and pepper"
 
 ## issue #51 inverted section
-@test Mustache.render("""{{^repos}}No repos :({{/repos}}""", Dict("repos" => [])) == "No repos :("    
+@test Mustache.render("""{{^repos}}No repos :({{/repos}}""", Dict("repos" => [])) == "No repos :("
 @test Mustache.render("{{^repos}}foo{{/repos}}",Dict("repos" => [Dict("name" => "repo name")])) == ""
 
 
@@ -99,3 +99,12 @@ tpl = """
 d = Dict("iterable"=>Dict("iterable2"=>["a","b","c"]), "lambda"=>(txt) -> "XXX $txt XXX")
 expected = "XXX a\nb\nc\n XXX"
 @test Mustache.render(tpl, d) == expected
+
+
+## Test with Named Tuples as a view
+tpl = "{{#:NT}}{{:a}} and {{:b}}{{/:NT}}"
+expected = "eh and bee"
+@test Mustache.render(tpl, NT=(a="eh", b="bee")) == expected
+
+expected = "eh and "
+@test Mustache.render(tpl, NT=(a="eh",)) == expected


### PR DESCRIPTION
Add ability to use named tuples as view, similar to Dicts. Keys are symbols.