### PR TITLE
issue 82, refix (take2)

### DIFF
--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -609,7 +609,7 @@ function renderTokens(io, tokens, writer, context, template)
                 ## Issue 82, what context to pass along to the partial
                 ## this makes "scope" of partial just the immediate value, not
                 ## the parent
-                renderTokens(io, tpl, writer, Context(value, Context(context.view,nothing)), template)
+                renderTokens(io, tpl, writer, Context(context.view,nothing), template)
             else
                 # can't find partial. Issue #83 requests signal, but this doesn't
                 # seem to match spec. Signal would go here.


### PR DESCRIPTION
better fix for issue #82, which didn't handle {{.}} tags properly.

This still treats the context for partials different than were the partial copied into the template, so may not be the proper way to do this, but this approach allows for recursive use of partial snippets and doesn't appear to contradict the mustache spec.