### PR TITLE
close issue #91

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.7
-Tables 0.1.4
+Tables 0.1.14

--- a/src/context.jl
+++ b/src/context.jl
@@ -87,10 +87,14 @@ end
 ## we special case dataframes here, so that we don't have to assume package is loaded
 function lookup_in_view(view, key)
     if Tables.istable(view)
-        r = first(Tables.rows(view))
-        if occursin(r"^:", key)  key = key[2:end] end
-        k = Symbol(key)
-        k in propertynames(r) ? getproperty(r, k) : nothing
+        if isempty(Tables.rows(view))
+            return nothing
+        else
+            r = first(Tables.rows(view))
+            if occursin(r"^:", key)  key = key[2:end] end
+            k = Symbol(key)
+            k in propertynames(r) ? getproperty(r, k) : nothing
+        end
     elseif  is_dataframe(view)
         if occursin(r"^:", key)  key = key[2:end] end
         key = Symbol(key)

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -434,8 +434,9 @@ end
 function renderTokensByValue(value, io, token, writer, context, template, args...)
     if Tables.istable(value)
         for row in Tables.rows(value)
-            #renderTokens(io, token.collector, writer, ctx_push(context, row), template, args...)
-            renderTokens(io, token.collector, writer, ctx_push(context, getfield(row,1)), template, args...)
+            @show "try this", row, token
+#            _renderTokensByValue(getfield(row,1), io, token, writer, context, template, args...)
+            renderTokens(io, token.collector, writer, ctx_push(context, row), template, args...)
         end
     elseif is_dataframe(value) # XXX remove once istable(x::DataFrame) == true works
         for i in 1:size(value)[1]

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -434,7 +434,8 @@ end
 function renderTokensByValue(value, io, token, writer, context, template, args...)
     if Tables.istable(value)
         for row in Tables.rows(value)
-            renderTokens(io, token.collector, writer, ctx_push(context, row), template, args...)
+            #renderTokens(io, token.collector, writer, ctx_push(context, row), template, args...)
+            renderTokens(io, token.collector, writer, ctx_push(context, getfield(row,1)), template, args...)
         end
     elseif is_dataframe(value) # XXX remove once istable(x::DataFrame) == true works
         for i in 1:size(value)[1]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -42,7 +42,12 @@ falsy(x::Array) = isempty(x)
 falsy(x::AbstractString) = x == ""
 falsy(x::Nothing) = true
 falsy(x::Missing) = true
-falsy(x) = (x == nothing) || false                #  default
+#falsy(x) = (x == nothing) || false                #  default
+function falsy(x)
+    Tables.istable(x) && isempty(Tables.rows(x)) && return true
+    x == nothing && return true
+    false
+end
 
 ## escape_html with entities
 

--- a/test/Mustache_test.jl
+++ b/test/Mustache_test.jl
@@ -126,7 +126,7 @@ filepath = joinpath(@__DIR__, "test-sections-crlf.tpl")
 @testset "closed issues" begin
 
     ## issue #51 inverted section
-#    @test Mustache.render("""{{^repos}}No repos :({{/repos}}""", Dict("repos" => [])) == "No repos :("
+    @test Mustache.render("""{{^repos}}No repos :({{/repos}}""", Dict("repos" => [])) == "No repos :("
     @test Mustache.render("{{^repos}}foo{{/repos}}",Dict("repos" => [Dict("name" => "repo name")])) == ""
 
 

--- a/test/Mustache_test.jl
+++ b/test/Mustache_test.jl
@@ -126,7 +126,7 @@ filepath = joinpath(@__DIR__, "test-sections-crlf.tpl")
 @testset "closed issues" begin
 
     ## issue #51 inverted section
-    @test Mustache.render("""{{^repos}}No repos :({{/repos}}""", Dict("repos" => [])) == "No repos :("
+#    @test Mustache.render("""{{^repos}}No repos :({{/repos}}""", Dict("repos" => [])) == "No repos :("
     @test Mustache.render("{{^repos}}foo{{/repos}}",Dict("repos" => [Dict("name" => "repo name")])) == ""
 
 

--- a/test/spec_inverted.jl
+++ b/test/spec_inverted.jl
@@ -75,20 +75,21 @@ tpl = """\"{{^a.b.c}}Not Here{{/a.b.c}}\" == \"Not Here\""""
 	@test Mustache.render(tpl, Dict{Any,Any}("a"=>Dict{Any,Any}())) == """\"Not Here\" == \"Not Here\""""
 
 	## Inverted sections should not alter surrounding whitespace.
-tpl = """ | {{^boolean}}	|	{{/boolean}} | 
+tpl = """ | {{^boolean}}	|	{{/boolean}} |
 """
 
-	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)) == """ | 	|	 | 
+	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)) == """ | 	|	 |
 """
 
 	## Inverted should not alter internal whitespace.
 tpl = """ | {{^boolean}} {{! Important Whitespace }}
- {{/boolean}} | 
+ {{/boolean}} |
 """
 
-	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)) == """ |  
-  | 
-"""
+        @test Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)) == " |  \n  |\n"
+#""" |\\s
+#  |
+#"""
 
 	## Single-line sections should not alter surrounding whitespace.
 tpl = """ {{^boolean}}NO{{/boolean}}
@@ -156,5 +157,3 @@ tpl = """|{{^ boolean }}={{/ boolean }}|"""
 
 	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>false)) == """|=|"""
 end
-
-


### PR DESCRIPTION
* works around misassumption that table rows are named tuples exposed by Tables.jl v0.1.14 
* works around `falsy` value for objects identified as `Tables.istable`.