### PR TITLE
expose tags, close issue #99

### DIFF
--- a/src/Mustache.jl
+++ b/src/Mustache.jl
@@ -59,15 +59,15 @@ render(tokens::MustacheTokens; kwargs...) = sprint(io -> render(io, tokens, Dict
 ##
 ## @param template a string containing the template for expansion
 ## @param view a Dict, Module, CompositeType, DataFrame holding variables for expansion
-function render(io::IO, template::AbstractString, view)
+function render(io::IO, template::AbstractString, view; tags= ("{{", "}}"))
     _writer = Writer()
-    render(io, _writer, parse(template), view)
+    render(io, _writer, parse(template, tags), view)
 end
 function render(io::IO, template::AbstractString; kwargs...)
     _writer = Writer()
     render(io, _writer, parse(template), Dict(kwargs...))
 end
-render(template::AbstractString, view) = sprint(io -> render(io, template, view))
+render(template::AbstractString, view; tags=("{{", "}}")) = sprint(io -> render(io, template, view, tags=tags))
 render(template::AbstractString; kwargs...) = sprint(io -> render(io, template, Dict(kwargs...)))
 
 ## Dict for storing parsed templates

--- a/test/Mustache_test.jl
+++ b/test/Mustache_test.jl
@@ -144,4 +144,14 @@ filepath = joinpath(@__DIR__, "test-sections-crlf.tpl")
     tpl = "{{#list}}{{ item }} {{/list}}"
     v = Dict("list"  => Any[Dict("item" => "one"),Dict("item" => "two")])
     @test Mustache.render(tpl, v) == "one two "
+
+    ## Issue 99 expose tags
+    tpl = "<<#list>><< item >> <</list>>"
+    v = Dict("list"  => Any[Dict("item" => "one"),Dict("item" => "two")])
+    @test Mustache.render(tpl, v, tags=("<<", ">>")) == "one two "
+
+
+    tpl = "[[#list]][[ item ]] [[/list]]"
+    @test Mustache.render(tpl, v, tags=("[[", "]]")) == "one two "
+
 end


### PR DESCRIPTION
* Allows ability to pass in different tags through tags keyword as a tuple: `render(tpl, view, tags=("((", "))"))`
* doesn't work when view is passed through keyword arguments (`render(tpl, a=1,b=2, ...)`), as this would prohibit `tags` as a key.