### PR TITLE
Change the Tables dependency version to include the 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 julia = "1.0"
-Tables = "0.2"
+Tables = "0.2, 1"
 
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,14 @@
 name = "Mustache"
 uuid = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-julia = "1.0"
 Tables = "0.2, 1"
-
+julia = "1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/context.jl
+++ b/src/context.jl
@@ -110,7 +110,7 @@ function lookup_in_view(view, key)
                 # work with a dictionary from the IteratorRow interface
                 # follows "Sinks (transferring data from one table to another)"
                 rD = Dict()
-                Tables.eachcolumn(sch, first(rows)) do val, col, name
+                Tables.eachcolumn(sch, rows) do val, col, name
                         rD[name] = val
                 end
                 k = occursin(r"^:", key)  ? Symbol(key[2:end])  : key


### PR DESCRIPTION
I was having troubles using Mustache with other packages as SQLite because the dependency in the 0.x version of Tables was dragging all the packages that depend on the new versions of Tables