### PR TITLE
fix missing value rendering

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -41,7 +41,7 @@ function lookup(ctx::Context, key)
     else
         context = ctx
         value = nothing
-        while value == nothing && context != nothing
+        while value === nothing && context !== nothing
             ## does name have a .?
             if occursin(r"\.", key)
                 value = lookup_dotted(context, key)
@@ -72,8 +72,6 @@ function lookup(ctx::Context, key)
                 value = lookup_in_view(context.view, stripWhitespace(key))
             end
             context = context.parent
-
-
         end
 
         ## cache

--- a/test/Mustache_test.jl
+++ b/test/Mustache_test.jl
@@ -193,3 +193,9 @@ tpl2 = mt"""
 
 end
 
+@testset "#124 regression test" begin
+    tpl = """{{^dims}}<input type="text" value="">{{/dims}}
+       {{#dims}}<textarea {{#.[1]}}cols="{{.}}"{{/.[1]}} {{#.[2]}}rows="{{.}}"{{/.[2]}}></textarea>{{/dims}}"""
+    @test render(tpl, Dict("dims"=>missing)) == "<input type=\"text\" value=\"\">\n"
+    @test render(tpl, Dict("dims"=>["1", "2"])) == "\n<textarea cols=\"1\" ></textarea><textarea  rows=\"2\"></textarea>"
+end


### PR DESCRIPTION
fix #124 

## After
```
julia> render(tpl, Dict("dims"=>missing))
"<input type=\"text\" value=\"\">\n"

julia> render(tpl, Dict("dims"=>["1", "2"]))
"\n<textarea cols=\"1\" ></textarea><textarea  rows=\"2\"></textarea>"
```