### PR TITLE
add a jmt macro with string interpolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Mustache"
 uuid = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
-version = "1.0.9"
+version = "1.0.10"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -243,9 +243,30 @@ tpl="""
 end
 ```
 
-(A string is used above -- and not a `mt` macro -- so that string
-interpolation can happen.)
+In the above, a string is used above -- and not a `mt` macro -- so that string
+interpolation can happen. The `jmt_str` string macro allows for substitution, so the above template could also have been more simply written as:
 
+```
+function df_to_table(df, label="label", caption="caption")
+    fmt = repeat("c", size(df,2))
+    header = join(string.(names(df)), " & ")
+    row = join(["{{:$x}}" for x in map(string, names(df))], " & ")
+
+tpl = jmt"""
+\begin{table}
+  \centering
+  \begin{tabular}{$fmt}
+  $header\\
+{{#:DF}}    $row\\
+{{/:DF}}  \end{tabular}
+  \caption{$caption}
+  \label{tab:$label}
+\end{table}
+"""
+
+    Mustache.render(tpl, DF=df)
+end
+```
 ### Iterating over vectors
 
 Though it isn't part of the Mustache specification, when iterating

--- a/src/Mustache.jl
+++ b/src/Mustache.jl
@@ -14,7 +14,7 @@ include("writer.jl")
 include("parse.jl")
 include("render.jl")
 
-export @mt_str, @mt_mstr, render, render_from_file
+export @mt_str, @jmt_str, render, render_from_file
 
 
 end

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -30,9 +30,65 @@ macro mt_str(s)
     parse(s)
 end
 
-macro mt_mstr(s)
-    parse(s)
+
+"""
+    jmt"string"
+
+Macro that interpolates values escaped by dollar signs, then parses strings.
+
+Note: modified from [HypertextLiteral](https://github.com/clarkevans/HypertextLiteral.jl/blob/master/src/macros.jl)
+
+Example:
+
+```
+x = 1
+toks = jmt"\$(2x) by {{:a}}"
+toks(a=2) # "2 by 2"
+```
+"""
+macro jmt_str(expr::String)
+    # Essentially this is an ad-hoc scanner of the string, splitting
+    # it by `$` to find interpolated parts and delegating the hard work
+    # to `Meta.parse`, treating everything else as a literal string.
+
+    args = Any[]
+    start = idx = 1
+    strlen = length(expr)
+    while true
+        idx = findnext(isequal('$'), expr, start)
+        if idx == nothing
+           push!(args, expr[start:strlen])
+           break
+        end
+        push!(args, expr[start:idx-1])
+        start = idx + 1
+        (nest, tail) = Meta.parse(expr, start; greedy=false)
+        if nest == nothing
+            throw("missing interpolation expression")
+        end
+        if !(expr[start] == '(' || nest isa Symbol)
+            throw(DomainError(nest,
+             "interpolations must be symbols or parenthesized"))
+        end
+        if Meta.isexpr(nest, :(=))
+            throw(DomainError(nest,
+             "assignments are not permitted in an interpolation"))
+        end
+        if nest isa String
+            # this is an interpolated string literal
+            nest = Expr(:string, nest)
+        end
+        push!(args, nest)
+        start = tail
+    end
+
+    quote
+        Mustache.parse(string($(map(esc, args)...)))
+    end
+
 end
+
+
 
 ## Dict for storing parsed templates
 TEMPLATES = Dict{AbstractString, MustacheTokens}()

--- a/test/Mustache_test.jl
+++ b/test/Mustache_test.jl
@@ -239,4 +239,9 @@ tpl = raw"\includegraphics{<<{:filename}>>}"
 tokens = Mustache.parse(tpl, ("<<",">>"))
 @test render(tokens, filename="XXX") == raw"\includegraphics{XXX}"
 
+## jmt macro
+x = 1
+tpl = jmt"$(2x) by {{:a}}"
+@test tpl(a=2) == "2 by 2"
+    
 end


### PR DESCRIPTION
Adds a `jmt_str` macro that handles julia interpolation before parsing (using the standard tags) into tokens.