### PR TITLE
close issue #139

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "Mustache"
 uuid = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
-version = "1.0.11"
+version = "1.0.12"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-Tables = "0.2, 1"
+Tables = "1"
 julia = "1.0"
 
 [extras]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -469,7 +469,8 @@ To summarize the different tags marking a variable:
 
 * `{{variable}}` does substitution of the value held in `variable` in the current view; escapes HTML characters
 * `{{{variable}}}` does substitution of the value held in `variable` in the current view; does not escape HTML characters. The mustache braces can be adjusted using `Mustache.parse`.
-* `{{-variable}}` does substitution of the value held in `variable` in the outmost view
+* `{{&variable}}` is an alternative syntax for triple braces (useful with custom braces)
+* `{{~variable}}` does substitution of the value held in `variable` in the outmost view
 * `{{#variable}}` depending on the type of variable, does the following:
    - if `variable` is not a container and is not absent or `nothing` will use the text between the matching tags, marked with `{{/variable}}`; otherwise that text will be skipped. (Like an `if/end` block.)
    - if `variable` is a `Tables.jl` compatible object (row wise, with named rows),  will iterate over the values, pushing the named tuple to be the top-most view for the part of the template up to `{{\variable}}`.
@@ -477,7 +478,7 @@ To summarize the different tags marking a variable:
 * `{{^variable}}`/`{{.variable}}` tags will show the values when `variable` is not defined, or is `nothing`.
 * `{{>partial}}` will include the partial value into the template, filling in the template using the current view. The partial can be a variable or a filename (checked with `isfile`).
 * `{{<partial}}` directly include partial value into template without filling in with the current view.
-
+* `{{!comment}}}` comments begin with a bang, `!`
 
 ## Alternatives
 

--- a/src/render.jl
+++ b/src/render.jl
@@ -23,11 +23,11 @@ function render(io::IO, tokens::MustacheTokens, view)
     render(io, _writer, tokens, view)
 end
 function render(io::IO, tokens::MustacheTokens; kwargs...)
-    render(io, tokens, kwargs)
+    render(io, tokens, Dict(kwargs...))
 end
 
 render(tokens::MustacheTokens, view) = sprint(io -> render(io, tokens, view))
-render(tokens::MustacheTokens; kwargs...) = sprint(io -> render(io, tokens, Dict(kwargs...)))
+render(tokens::MustacheTokens; kwargs...) = sprint(io -> render(io, tokens; kwargs...))
 
 ## make MustacheTokens callable for kwargs...
 function (m::MustacheTokens)(io::IO, args...; kwargs...)
@@ -46,15 +46,13 @@ end
 ## @param template a string containing the template for expansion
 ## @param view a Dict, Module, CompositeType, DataFrame holding variables for expansion
 function render(io::IO, template::AbstractString, view; tags= ("{{", "}}"))
-    _writer = Writer()
-    render(io, _writer, parse(template, tags), view)
+    return render(io, parse(template, tags), view)
 end
 function render(io::IO, template::AbstractString; kwargs...)
-    _writer = Writer()
-    render(io, _writer, parse(template), Dict(kwargs...))
+    return render(io, parse(template); kwargs...)
 end
 render(template::AbstractString, view; tags=("{{", "}}")) = sprint(io -> render(io, template, view, tags=tags))
-render(template::AbstractString; kwargs...) = sprint(io -> render(io, template, Dict(kwargs...)))
+render(template::AbstractString; kwargs...) = sprint(io -> render(io, template; kwargs...))
 
 
 # Exported, but should be deprecated....

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -38,7 +38,7 @@ end
 ## this is for falsy value
 ## Falsy is true if x is false, 0 length, "", ...
 falsy(x::Bool) = !x
-falsy(x::Array) = isempty(x)
+falsy(x::Array) = isempty(x) || all(falsy, x)
 falsy(x::AbstractString) = x == ""
 falsy(x::Nothing) = true
 falsy(x::Missing) = true
@@ -74,6 +74,15 @@ end
 function escapeTags(tags)
    [Regex(escapeRe(tags[1]) * "\\s*"),
     Regex("\\s*" * escapeRe(tags[2]))]
+end
+
+# key may be string or a ":symbol"
+function normalize(key)
+    if occursin(r"^:", key)
+        key = key[2:end]
+        key = Symbol(key)
+    end
+    return key
 end
 
 


### PR DESCRIPTION
Close issue #139 which was due to mishandling of Tables.jl data with partials

This also cleaned up a few things
* change lookup in context for Tables.jl data -- find "column" if key is present, not first element
* cleaned up `render(...)` resolution to avoid multiple routes
* added utility function `normalize` to turn strings like ":key" to symbols `:key` leaving strings alone
* dropped special casing of dataframes, use Tables.jl now
* minor adjustment to docs