### PR TITLE
Support variables from root context

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Mustache"
 uuid = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
-version = "1.0.16"
+version = "1.0.17"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/src/context.jl
+++ b/src/context.jl
@@ -65,23 +65,26 @@ function lookup(ctx::Context, key)
                 ## do something with "."
                 ## we use .[ind] to refer to value in parent of given index;
                 m = match(r"^\.\[(.*)\]$", key)
-                m === nothing && break
 
-                idx = m.captures[1]
-                vals = context.parent.view
 
-                # this has limited support for indices: "end", or a number, but no
-                # arithmetic, such as `end-1`.
-                ## This is for an iterable; rather than
-                ## limit the type, we let non-iterables error.
-                if true # isa(vals, AbstractVector)  || isa(vals, Tuple) # supports getindex(v, i)?
-                if idx == "end"
-                    value′ = AnIndex(-1, vals[end])
+                if m !== nothing
+                    idx = m.captures[1]
+                    vals = context.parent.view
+
+                    # this has limited support for indices: "end", or a number, but no
+                    # arithmetic, such as `end-1`.
+                    ## This is for an iterable; rather than
+                    ## limit the type, we let non-iterables error.
+                    if true # isa(vals, AbstractVector)  || isa(vals, Tuple) # supports getindex(v, i)?
+                        if idx == "end"
+                            value′ = AnIndex(-1, vals[end])
+                        else
+                            ind = Base.parse(Int, idx)
+                            value′ = AnIndex(ind, string(vals[ind]))
+                        end
+                    end
                 else
-                    ind = Base.parse(Int, idx)
-                    value′ = AnIndex(ind, string(vals[ind]))
-                end
-                    #break
+                    !global_lookup && break
                 end
             end
         end

--- a/test/spec_sections.jl
+++ b/test/spec_sections.jl
@@ -203,6 +203,18 @@ tpl = """#{{#boolean}}
 tpl = """|{{# boolean }}={{/ boolean }}|"""
 
 	@test Mustache.render(tpl, Dict{Any,Any}("boolean"=>true)) == """|=|"""
+
+
+	## Nested object fields should be accessible via global lookup
+tpl = """|{{# inner }}{{ field.subfield }}{{/ inner }} {{# inner }}{{ ~field.subfield }}{{/ inner }}|"""
+
+	@test Mustache.render(tpl, Dict{Any,Any}("inner"=>Dict("field"=>Dict("subfield"=>1)),"field"=>Dict("subfield"=>2))) == """|1 2|"""
+
+	## Local lookup should resolve local object if it is present
+tpl = """|{{# inner }}{{{ field }}}{{/ inner }} {{# inner }}{{ ~field.subfield }}{{/ inner }}|"""
+
+	@test Mustache.render(tpl, Dict{Any,Any}("inner"=>Dict("field"=>Dict()),"field"=>Dict("subfield"=>2))) == """|Dict{Any, Any}() 2|"""
+
 end
 
 

--- a/test/spec_sections.jl
+++ b/test/spec_sections.jl
@@ -209,12 +209,6 @@ tpl = """|{{# boolean }}={{/ boolean }}|"""
 tpl = """|{{# inner }}{{ field.subfield }}{{/ inner }} {{# inner }}{{ ~field.subfield }}{{/ inner }}|"""
 
 	@test Mustache.render(tpl, Dict{Any,Any}("inner"=>Dict("field"=>Dict("subfield"=>1)),"field"=>Dict("subfield"=>2))) == """|1 2|"""
-
-	## Local lookup should resolve local object if it is present
-tpl = """|{{# inner }}{{{ field }}}{{/ inner }} {{# inner }}{{ ~field.subfield }}{{/ inner }}|"""
-
-	@test Mustache.render(tpl, Dict{Any,Any}("inner"=>Dict("field"=>Dict()),"field"=>Dict("subfield"=>2))) == """|Dict{Any, Any}() 2|"""
-
 end
 
 


### PR DESCRIPTION
Fixing issue that you can `{{# inner }}{{ ~field }}{{/ inner }}` but can not {{# inner }}{{ ~field.subfield }}{{/ inner }}