### PR TITLE
Delete the `REQUIRE` file

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 1.0
-Tables 0.1.14


### PR DESCRIPTION
The `REQUIRE` file is no longer needed, because we use `Project.toml` instead.